### PR TITLE
Better error handling

### DIFF
--- a/covstats.wdl
+++ b/covstats.wdl
@@ -29,10 +29,7 @@ task getReadLengthAndCoverage {
 
 	command <<<
 
-		# For some reason, Cromwell handles panics in go TOO well.
-		# In other words, a panic (fatal error) in go is perfectly
-		# capable of reporting as a successful task/workflow run.
-		# Unfortunately this means we need to catch them ourselves.
+		set -eux -o pipefail
 
 		if [ -f ~{inputBamOrCram} ]; then
 			echo "Input bam file exists"

--- a/covstats.wdl
+++ b/covstats.wdl
@@ -41,27 +41,25 @@ task getReadLengthAndCoverage {
 			exit 1
 		fi
 		
-		# If the user passes in the indeces, they will be in the same input folder
-		# as the input bams and crams. If samtools index was called to generate the
-		# indeces, then they will be in a different folder, hence the need for two
-		# checks. Unfortunately neither cover the "user defined an input that is like
-		# foo.bai instead of foo.bam.bai" so for now failing both does not exit 1
+		# If the user passes in the indeces, they will be in the same folder
+		# as the input bams/crams. If samtools index was called to generate
+		# the indeces, then they will be in a different folder.
+
+		OTHERPOSSIBILITY=$(echo ~{inputBamOrCram} | sed 's/\.[^.]*$//')
+		echo "${OTHERPOSSIBILITY}.bai"
 
 		if [ -f ~{inputBamOrCram}.bai ]; then
-			echo "Input bai file exists, likely passed in by user"
+			echo "Bai file, likely passed in by user, exists with pattern *.bam.bai"
 		else
-			if [ -f ~{inputIndex} ]; then
-				echo "Input bai file exists, likely output of samtools index"
+			if [ ~{inputIndex} != ~{inputBamOrCram} ]; then
+				echo "Bai file, likely output of samtools index, exists with pattern *.bam.bai"
 			else
-				>&2 echo "Cursory search for the index file failed. Task may still succeed."
-				#echo "~{inputBamOrCram}" | sed 's/\.[^.]*$//'
-				#otherPossibility=$("~{inputBamOrCram}" | sed 's/\.[^.]*$//')
-				#if [-f ${otherPossibility}.bai]; then
-					#echo "Input has been found"
-				#else
-					#>&2 echo "Input bai file (~{inputBamOrCram}.bai) nor ${otherPossibility}.bai not found, panic"
-					#exit 1
-				#fi
+				if [ -f ${OTHERPOSSIBILITY}.bai ]; then
+					echo "Bai file, likely passed in by user, exists with pattern *.bai"
+				else
+					>&2 echo "Input bai file (~{inputBamOrCram}.bai) nor ${otherPossibility}.bai not found, panic"
+					exit 1
+				fi
 			fi
 		fi
 

--- a/localcov.json
+++ b/localcov.json
@@ -5,5 +5,5 @@
  ],
   "covstats.inputIndexes": [
     "/Users/ash/Documents/aaa_test_files/bam-1000genomes/NA12878.chrom20.ILLUMINA.bwa.CEU.low_coverage.20121211.bai",
-    "/Users/ash/Documents/aaa_test_files/bam-1000genomes/NA12878.chrom21.ILLUMINA.bwa.CEU.high_coverage.20100311.bai"]
+    "/Users/ash/Documents/aaa_test_files/bam-1000genomes/NA12878.chrom21.ILLUMINA.bwa.CEU.high_coverage.20100311.bam.bai"]
 }

--- a/localcov.json
+++ b/localcov.json
@@ -4,6 +4,6 @@
     "/Users/ash/Documents/aaa_test_files/bam-1000genomes/NA12878.chrom21.ILLUMINA.bwa.CEU.high_coverage.20100311.bam"
  ],
   "covstats.inputIndexes": [
-    "/Users/ash/Documents/aaa_test_files/bam-1000genomes/NA12878.chrom20.ILLUMINA.bwa.CEU.low_coverage.20121211.bam.bai",
-    "/Users/ash/Documents/aaa_test_files/bam-1000genomes/NA12878.chrom21.ILLUMINA.bwa.CEU.high_coverage.20100311.bam.bai"]
+    "/Users/ash/Documents/aaa_test_files/bam-1000genomes/NA12878.chrom20.ILLUMINA.bwa.CEU.low_coverage.20121211.bai",
+    "/Users/ash/Documents/aaa_test_files/bam-1000genomes/NA12878.chrom21.ILLUMINA.bwa.CEU.high_coverage.20100311.bai"]
 }


### PR DESCRIPTION
Working draft of WDLized covstats. You can ignore goleft.wdl, that was just a proof of concept.

~~Known bug: If passed in foo.bai as opposed to foo.bam.bai, we will get an error. I am pretty sure the error is occuring in the go portion, not the WDL portion, and "magic number mismatch" is a bit beyond my abilities as a non-magic person to debug. 🧙 As with all go errors, Cromwell will not pick up on it. However, this is thankfully not a silent error as during the output part of the task, it will detect bad output and error out.~~ Edit: Fixed!