### PR TITLE
Terra support via filesize estimation + preemptibles

### DIFF
--- a/covstats/covstats.wdl
+++ b/covstats/covstats.wdl
@@ -85,14 +85,6 @@ task getReadLengthAndCoverage {
 		duration=$(( SECONDS - start ))
 		echo ${duration} > duration
 
-		goleft covstats ~{inputBamOrCram} >> this.txt
-		COVOUT=$(tail -n +2 this.txt)
-		read -a COVARRAY <<< "$COVOUT"
-		echo ${COVARRAY[0]} > thisCoverage
-		echo ${COVARRAY[11]} > thisReadLength
-		BASHFILENAME=$(basename ~{inputBamOrCram})
-		echo "'${BASHFILENAME}'" > thisFilename
-
 	>>>
 
 	# Estimate disk size required

--- a/covstats/covstats.wdl
+++ b/covstats/covstats.wdl
@@ -5,24 +5,9 @@ task getReadLengthAndCoverage {
 		File inputBamOrCram
 		Array[File] allInputIndexes
 		File? refGenome
-
-		# DEBUG
-		Int? refSize = ceil(size(refGenome, "GB"))
-		Int? indexSize = ceil(size(allInputIndexes, "GB"))
-		Int? thisAmSize = ceil(size(inputBamOrCram, "GB"))
 	}
 
 	command <<<
-		# DELETE -- DEBUG ONLY -- PRINT DISK SIZE
-		#finalDiskSize = ~{refSize} + ~{indexSize} + (2*~{thisAmSize})
-		echo "ref " > thisSize
-		echo ~{refSize} >> thisSize
-		echo "index " >> thisSize
-		echo ~{indexSize} >> thisSize
-		echo "this file " >> thisSize
-		echo ~{thisAmSize} >> thisSize
-		#echo "final " >> thisSize
-		#echo ~{finalDiskSize} >> finalDiskSize
 
 		start=$SECONDS
 
@@ -89,7 +74,7 @@ task getReadLengthAndCoverage {
 
 	# Estimate disk size required
 	Int refSize = ceil(size(refGenome, "GB"))
-	Int indexSize = ceil(size(allInputIndexes))
+	Int indexSize = ceil(size(allInputIndexes, "GB"))
 	#lets see if we can do this on a task level to save space
 	#Int amSize = ceil(size(inputBamsOrCrams, "GB"))
 	Int thisAmSize = ceil(size(inputBamOrCram, "GB"))

--- a/covstats/covstats.wdl
+++ b/covstats/covstats.wdl
@@ -97,7 +97,7 @@ task getReadLengthAndCoverage {
 	runtime {
 		docker: "quay.io/biocontainers/goleft:0.2.0--0"
 		preemptible: 1
-		disks: "local-disk" + finalDiskSize + " HDD"
+		disks: "local-disk " + finalDiskSize + " HDD"
 	}
 }
 


### PR DESCRIPTION
covstats.wdl now calculates disk size needed for each of its inputs. This is needed because without a disk size runtime attribute, the workflow will fail on Terra once it hits about 10 gigabytes. 

Because the covstats task is scattered and localization of inputs is deferred until a task calls upon them, we have the luxury of calculating every input cram/bam file seperately and requesting its own amount of space for every instance of the scattered task -- ie, if you input a 10 GB cram and a 50 GB cram, plus hg38 as the ref, you will request 24 GB (2x10 + 4) and 104 GB (2x50 + 4) respectively rather than 124 GB. The factor of 2 is because cram files (and ONLY cram files) are modified by samtools during covstats and that itself requires disk space. It appears that scales linearly; I ran this on several 30x crams with no problem.

Preemptibles were also added to bring costs down, as all tasks involved tend to take less than an hour each.