### PR TITLE
1814/specify memory disk preempts

### DIFF
--- a/covstats/checker.wdl
+++ b/covstats/checker.wdl
@@ -8,7 +8,7 @@ version 1.0
 # samtools can work a little differently. Keep that in mind especially if you wish to
 # roll your own Docker image here.
 
-import "https://github.com/nolwarre/covstats-wdl/raw/1814/specify-memory-disk-preempts/covstats/covstats.wdl" as covstats
+import "https://raw.githubusercontent.com/aofarrel/covstats-wdl/master/covstats/covstats.wdl" as covstats
 
 task md5sum {
   input {

--- a/covstats/checker.wdl
+++ b/covstats/checker.wdl
@@ -8,7 +8,7 @@ version 1.0
 # samtools can work a little differently. Keep that in mind especially if you wish to
 # roll your own Docker image here.
 
-import "https://raw.githubusercontent.com/aofarrel/covstats-wdl/specfify-memory-disk-preempts/covstats/covstats.wdl" as covstats
+import "https://github.com/nolwarre/covstats-wdl/raw/1814/specify-memory-disk-preempts/covstats/covstats.wdl" as covstats
 
 task md5sum {
   input {

--- a/covstats/checker.wdl
+++ b/covstats/checker.wdl
@@ -2,13 +2,13 @@ version 1.0
 
 # NOTE: If you wish to adapt this checker and make your own truth files, go ahead, but
 # I recommend that you always check both of the following:
-# 1) A cram file 
+# 1) A cram file
 # 2) A bam file, without also inputting its index
 # Both of these cases require calling samtools and as we all know different versions of
 # samtools can work a little differently. Keep that in mind especially if you wish to
 # roll your own Docker image here.
 
-import "https://raw.githubusercontent.com/aofarrel/covstats-wdl/master/covstats/covstats.wdl" as covstats
+import "https://raw.githubusercontent.com/aofarrel/covstats-wdl/specfify-memory-disk-preempts/covstats/covstats.wdl" as covstats
 
 task md5sum {
   input {
@@ -19,7 +19,7 @@ task md5sum {
 
   command <<<
 
-  # Terra can mix up files 
+  # Terra can mix up files
 
   sort ~{report} > newreport.txt
   sort ~{truth} > newtruth.txt
@@ -78,8 +78,8 @@ workflow checker {
   # Call covstats
   scatter(oneBamOrCram in inputBamsOrCrams) {
     Array[String] allOrNoIndexes = select_first([inputIndexes, wholeLottaNada])
-    
-    call covstats.getReadLengthAndCoverage as scatteredGetStats { 
+
+    call covstats.getReadLengthAndCoverage as scatteredGetStats {
       input:
         inputBamOrCram = oneBamOrCram,
         refGenome = refGenome,

--- a/covstats/covstats.wdl
+++ b/covstats/covstats.wdl
@@ -6,6 +6,9 @@ task getReadLengthAndCoverage {
 		Array[File] allInputIndexes
 		File? refGenome
 		String toUse
+		Int memSize
+		Int preemptible
+		Int additionalDisk
 	}
 
 	command <<<
@@ -22,7 +25,7 @@ task getReadLengthAndCoverage {
 
 		if [ -f ~{inputBamOrCram} ]; then
 				echo "Input bam or cram file exists"
-		else 
+		else
 				>&2 echo "Input bam or cram file ~{inputBamOrCram} not found, panic"
 				exit 1
 		fi
@@ -46,7 +49,7 @@ task getReadLengthAndCoverage {
 				>&2 echo "A reference genome is required for cram inputs."
 				exit 1
 			fi
-		
+
 		else
 			# Bam file
 
@@ -65,7 +68,7 @@ task getReadLengthAndCoverage {
 				echo "Finding neither, we will index with samtools."
 				samtools index ~{inputBamOrCram} ~{inputBamOrCram}.bai
 			fi
-			
+
 			goleft covstats -f ~{refGenome} ~{inputBamOrCram} >> this.txt
 
 			COVOUT=$(tail -n +2 this.txt)
@@ -95,7 +98,7 @@ task getReadLengthAndCoverage {
 	# in terms of determining if something is a cram ahead of time
 	# in order to maximize savings.
 
-	Int finalDiskSize = refSize + indexSize + (2*thisAmSize)
+	Int finalDiskSize = refSize + indexSize + (2*thisAmSize) + additionalDisk
 
 	output {
 		Int outReadLength = read_int("thisReadLength")
@@ -105,8 +108,9 @@ task getReadLengthAndCoverage {
 	}
 	runtime {
 		docker: if toUse == "true" then "quay.io/biocontainers/goleft:0.2.0--0" else "quay.io/aofarrel/goleft-covstats:circleci-push"
-		preemptible: 1
+		preemptible: preemptible
 		disks: "local-disk " + finalDiskSize + " HDD"
+		memory: memSize + "G"
 	}
 }
 
@@ -117,6 +121,8 @@ task report {
 		Array[String] filenames
 		Int lenReads = length(readLengths)
 		Int lenCov = length(coverages)
+		Int memSize
+		Int preemptible
 	}
 
 	command <<<
@@ -156,7 +162,8 @@ task report {
 
 	runtime {
 		docker: "python:3.8-slim"
-		preemptible: 2
+		preemptible: preemptible
+		memory: memSize + "G"
 	}
 }
 
@@ -166,6 +173,11 @@ workflow covstats {
 		Array[File]? inputIndexes
 		File? refGenome
 		String? useLegacyContainer
+		Int covstatsMem = 2
+		Int reportMem = 2
+		Int additionalDisk = 1
+		Int covstatsPreemptible = 1
+		Int reportPreemptible = 1
 	}
 
 	# Fallback if no indecies are defined. Other methods exist but this is
@@ -176,7 +188,7 @@ workflow covstats {
 	# The choose container is printed in the task itself
 	String toUse = select_first([useLegacyContainer, "false"])
 
-	# Catching input typos from user doesn't seem possible due to how variables 
+	# Catching input typos from user doesn't seem possible due to how variables
 	# are scoped unfortunately, but I did make an attempt which I stored here
 	# https://gist.github.com/aofarrel/ef71e1a27d824cbcc8acb11b6abe6e19
 	# in case some brave soul wants to take a crack at it
@@ -184,13 +196,16 @@ workflow covstats {
 	# Call covstats
 	scatter(oneBamOrCram in inputBamsOrCrams) {
 		Array[String] allOrNoIndexes = select_first([inputIndexes, wholeLottaNada])
-		
-		call getReadLengthAndCoverage as scatteredGetStats { 
+
+		call getReadLengthAndCoverage as scatteredGetStats {
 			input:
 				inputBamOrCram = oneBamOrCram,
 				refGenome = refGenome,
 				allInputIndexes = allOrNoIndexes,
-				toUse = toUse
+				toUse = toUse,
+				memSize = covstatsMem,
+				additionalDisk = additionalDisk,
+				preemptible = covstatsPreemptible
 		}
 	}
 
@@ -199,7 +214,9 @@ workflow covstats {
 		input:
 			readLengths = scatteredGetStats.outReadLength,
 			coverages = scatteredGetStats.outCoverage,
-			filenames = scatteredGetStats.outFilenames
+			filenames = scatteredGetStats.outFilenames,
+			memSize = reportMem,
+			preemptible = reportPreemptible
 	}
 
 	meta {

--- a/covstats/covstats.wdl
+++ b/covstats/covstats.wdl
@@ -7,8 +7,8 @@ task getReadLengthAndCoverage {
 		File? refGenome
 		String toUse
 		# runtime attributes with defaults
-		Int memSize = 2
-		Int preemptible = 0
+		Int covstatsMemSize = 2
+		Int covstatsPreempt = 1
 		Int additionalDisk = 0
 	}
 
@@ -109,9 +109,9 @@ task getReadLengthAndCoverage {
 	}
 	runtime {
 		docker: if toUse == "true" then "quay.io/biocontainers/goleft:0.2.0--0" else "quay.io/aofarrel/goleft-covstats:circleci-push"
-		preemptible: preemptible
+		preemptible: covstatsPreempt
 		disks: "local-disk " + finalDiskSize + " HDD"
-		memory: memSize + "G"
+		memory: covstatsMemSize + "G"
 	}
 }
 
@@ -122,9 +122,9 @@ task report {
 		Array[String] filenames
 		Int lenReads = length(readLengths)
 		Int lenCov = length(coverages)
-		# user runtime attributes
-		Int memSize = 2
-		Int preemptible = 2
+		# runtime attributes
+		Int reportMemSize = 2
+		Int reportPreempt = 2
 	}
 
 	command <<<
@@ -164,8 +164,8 @@ task report {
 
 	runtime {
 		docker: "python:3.8-slim"
-		preemptible: preemptible
-		memory: memSize + "G"
+		preemptible: reportPreempt
+		memory: reportMemSize + "G"
 	}
 }
 
@@ -176,9 +176,9 @@ workflow covstats {
 		File? refGenome
 		String? useLegacyContainer
 		# runtime attributes for covstats
-		Int covstatsMem = 2
+		Int covstatsMem = 8
 		Int additionalDisk = 0
-		Int covstatsPreemptible = 0
+		Int covstatsPreemptible = 1
 		# runtme attributes for report
 		Int reportMem = 2
 		Int reportPreemptible = 2
@@ -207,9 +207,9 @@ workflow covstats {
 				refGenome = refGenome,
 				allInputIndexes = allOrNoIndexes,
 				toUse = toUse,
-				memSize = covstatsMem,
+				covstatsMemSize = covstatsMem,
 				additionalDisk = additionalDisk,
-				preemptible = covstatsPreemptible
+				covstatsPreempt = covstatsPreemptible
 		}
 	}
 
@@ -219,8 +219,8 @@ workflow covstats {
 			readLengths = scatteredGetStats.outReadLength,
 			coverages = scatteredGetStats.outCoverage,
 			filenames = scatteredGetStats.outFilenames,
-			memSize = reportMem,
-			preemptible = reportPreemptible
+			reportMemSize = reportMem,
+			reportPreempt = reportPreemptible
 	}
 
 	meta {

--- a/covstats/covstats.wdl
+++ b/covstats/covstats.wdl
@@ -8,7 +8,7 @@ task getReadLengthAndCoverage {
 		String toUse
 		# runtime attributes with defaults
 		Int memSize = 2
-		Int preemptible = 1
+		Int preemptible = 0
 		Int additionalDisk = 0
 	}
 
@@ -178,10 +178,10 @@ workflow covstats {
 		# runtime attributes for covstats
 		Int covstatsMem = 2
 		Int additionalDisk = 0
-		Int covstatsPreemptible = 1
+		Int covstatsPreemptible = 0
 		# runtme attributes for report
 		Int reportMem = 2
-		Int reportPreemptible = 1
+		Int reportPreemptible = 2
 	}
 
 	# Fallback if no indecies are defined. Other methods exist but this is

--- a/covstats/covstats.wdl
+++ b/covstats/covstats.wdl
@@ -6,9 +6,10 @@ task getReadLengthAndCoverage {
 		Array[File] allInputIndexes
 		File? refGenome
 		String toUse
-		Int memSize
-		Int preemptible
-		Int additionalDisk
+		# runtime attributes with defaults
+		Int memSize = 2
+		Int preemptible = 1
+		Int additionalDisk = 0
 	}
 
 	command <<<
@@ -121,8 +122,9 @@ task report {
 		Array[String] filenames
 		Int lenReads = length(readLengths)
 		Int lenCov = length(coverages)
-		Int memSize
-		Int preemptible
+		# user runtime attributes
+		Int memSize = 2
+		Int preemptible = 2
 	}
 
 	command <<<
@@ -173,10 +175,12 @@ workflow covstats {
 		Array[File]? inputIndexes
 		File? refGenome
 		String? useLegacyContainer
+		# runtime attributes for covstats
 		Int covstatsMem = 2
-		Int reportMem = 2
-		Int additionalDisk = 1
+		Int additionalDisk = 0
 		Int covstatsPreemptible = 1
+		# runtme attributes for report
+		Int reportMem = 2
 		Int reportPreemptible = 1
 	}
 


### PR DESCRIPTION
Added user specifier runtime attributes.

Tasks that should have user-specified preempts: both of them
Tasks that should have user-specified memory: both of them
Tasks that should have an option to kick up the disk size: probably just the actual covstats task, not the report task